### PR TITLE
init: Let a device's init.rc redefine service entries

### DIFF
--- a/init/keywords.h
+++ b/init/keywords.h
@@ -82,6 +82,7 @@ enum {
     KEYWORD(rmdir,       COMMAND, 1, do_rmdir)
     KEYWORD(seclabel,    OPTION,  0, 0)
     KEYWORD(service,     SECTION, 0, 0)
+    KEYWORD(service_redefine,     SECTION, 0, 0)
     KEYWORD(setcon,      COMMAND, 1, do_setcon)
     KEYWORD(setenforce,  COMMAND, 1, do_setenforce)
     KEYWORD(setenv,      OPTION,  2, 0)


### PR DESCRIPTION
In case of duplicate service definitions, init.rc's version always
wins. This is a less-than-ideal situation and the main reason for
some devices to override the default init.rc, which leads to out-of-sync
situations whenever we happen to insert something into the main copy.

So let services be overridden. To prevent accidental override of
system services, use a specific keyword for this, "service_redefine"

Change-Id: Ib1cab6bd3008956e9a2f61355781861ef8bcf8ca